### PR TITLE
use $data_dir from the configuration

### DIFF
--- a/webdav_server.php
+++ b/webdav_server.php
@@ -5,6 +5,6 @@ chdir (dirname(__FILE__) . "/inc");
 require_once "HTTP/WebDAV/Server/Filesystem.php";
 $server = new HTTP_WebDAV_Server_Filesystem();
 
-$server->ServeRequest(dirname(__FILE__) . "/data");
+$server->ServeRequest(dirname(__FILE__) . $data_dir);
 
 ?>


### PR DESCRIPTION
The $data_dir configuration variable isn't used whereas it exists in settings.php.
It is necessary, for example, to install the webdav server on heroku, which requires to put the data in the tmp directory.

This makes usage of the $data_dir configuration variable.

---

Note to anyone discovering this because I mentioned heroku :)
You shouldn't use this project on heroku, unless you want the webdav server for development and tests purposes (that's my case).
The tmp directory in heroku is the only one where we can write to. But it's not persisted accross deployments. So you'd lose your data regularly. Do not rely on it.

---

See also krueschan/phpZoteroWebDAV#3
